### PR TITLE
Extends time for login to length of 1 day.

### DIFF
--- a/backend/api_token.php
+++ b/backend/api_token.php
@@ -97,7 +97,7 @@
             $result = api_response::getResponse(500);
             $token = $this->tokenGen();
             $dateTime = new DateTime();
-            $dateTime->add(new DateInterval("PT10H"));
+            $dateTime->add(new DateInterval("PT1D"));
             $dateValue = $dateTime->format("Y-m-d H:i:s");
             $dbToken = new db_token();
             try{


### PR DESCRIPTION
Identified problem where the login token is being deleted before it should. Not sure if there is some sort of time mismatch or what but we'll extend it out to 24 hours to see if that corrects the problem.