### PR TITLE
Automatically scroll down a bit to reveal Datenschutz or Impressum

### DIFF
--- a/index.html
+++ b/index.html
@@ -1253,7 +1253,9 @@
             $(".navbar").css("background-color", "rgba(225, 208, 192," + rgba + ")");
         });
 
-
+        // Automatically scroll down a bit when clicking on the Datenschutz or Impressum link
+        document.getElementById("openDatenschutz").addEventListener("click", ()=>window.setTimeout(()=>location.assign("#openImpressum"),50));
+        document.getElementById("openImpressum").addEventListener("click", ()=>window.setTimeout(()=>location.assign("#openDatenschutz"),50));
 
     </script>
 </body>


### PR DESCRIPTION
Automatically scroll down a bit when opening Datenschutz or Impressum as it is only extending the page currently.